### PR TITLE
#2 issue is done

### DIFF
--- a/Snake/src/ge/edu/freeuni/sdp/snake/App.java
+++ b/Snake/src/ge/edu/freeuni/sdp/snake/App.java
@@ -1,7 +1,12 @@
 package ge.edu.freeuni.sdp.snake;
 
+import ge.edu.freeuni.sdp.snake.model.CompositePopulator;
 import ge.edu.freeuni.sdp.snake.model.Configuration;
 import ge.edu.freeuni.sdp.snake.model.Level;
+import ge.edu.freeuni.sdp.snake.model.MovingMousePopulator;
+import ge.edu.freeuni.sdp.snake.model.MovingPoisonBeing;
+import ge.edu.freeuni.sdp.snake.model.MovingPoisonPopulator;
+import ge.edu.freeuni.sdp.snake.model.Populator;
 import ge.edu.freeuni.sdp.snake.model.SingleMousePopulator;
 import ge.edu.freeuni.sdp.snake.model.Size;
 import ge.edu.freeuni.sdp.snake.model.SphericTopology;
@@ -29,9 +34,16 @@ public class App {
 				"Very Simple Level", 
 				new SphericTopology(),
 				new SingleMousePopulator());
+		
+		Populator[] array = {new MovingMousePopulator(),new MovingPoisonPopulator()};
+		Level level2 = new Level(
+				"Moving Poison & Mouse Level", 
+				new SphericTopology(),
+				new CompositePopulator(array));
 
 		//TODO Add other levels here
 		levels.add(level1);
+		levels.add(level2);
 
 		Configuration.init(size, levels);
 		

--- a/Snake/src/ge/edu/freeuni/sdp/snake/model/Being.java
+++ b/Snake/src/ge/edu/freeuni/sdp/snake/model/Being.java
@@ -53,4 +53,18 @@ public abstract class Being {
 	 * @param direction
 	 */
 	public abstract void setDirection(Direction direction);
+	
+	/**
+	 * Checks if being is connected with another (Being)obj and returns true if so.
+	 * This boolean value is used to decide, whether to call interactWith. 
+	 * @param obj another Being
+	 * @return true or false
+	 */
+	public abstract boolean isConnected(Object obj);
+	
+	/**
+	 * Returns previous head point before current head value.
+	 * @return
+	 */
+	public abstract Point getNeck();
 }

--- a/Snake/src/ge/edu/freeuni/sdp/snake/model/FixedBeing.java
+++ b/Snake/src/ge/edu/freeuni/sdp/snake/model/FixedBeing.java
@@ -31,4 +31,13 @@ public abstract class FixedBeing extends Being {
 	public final void setDirection(Direction direction) {
 	}
 
+	@Override
+	public Point getNeck() {
+		return null;
+	}
+	
+	@Override
+	public boolean isConnected(Object obj){
+		return contains(((Being) obj).getHead());
+	}
 }

--- a/Snake/src/ge/edu/freeuni/sdp/snake/model/LittleMovingBeing.java
+++ b/Snake/src/ge/edu/freeuni/sdp/snake/model/LittleMovingBeing.java
@@ -1,0 +1,50 @@
+package ge.edu.freeuni.sdp.snake.model;
+
+import java.util.Random;
+
+public abstract class LittleMovingBeing extends MovingBeing{
+	private Point point;
+	private long lastChange;
+	private Point previousPoint;
+	
+	public LittleMovingBeing(Point point) {
+		previousPoint = point;
+		this.point = point;
+		setRandomDirection();
+		lastChange = System.currentTimeMillis();
+	}
+	
+	private void setRandomDirection() {
+		Random random = new Random();
+		Direction [] array = {Direction.LEFT,Direction.RIGHT,Direction.UP,Direction.DOWN};
+		int index = random.nextInt(4);
+	    setDirection(array[index]);
+	}
+	
+	@Override
+	protected void moveTo(Point point) {
+		previousPoint = this.point;
+		this.point = point;
+		long currentTime = System.currentTimeMillis();
+		if (currentTime-lastChange >= 5*1000){
+			setRandomDirection();
+			lastChange = currentTime;
+		}
+	}
+
+	@Override
+	public boolean contains(Point point) {
+		return this.point.equals(point);
+	}
+
+	@Override
+	public Point getHead() {
+		return this.point;
+	}
+	
+	@Override
+	public Point getNeck() {
+		return previousPoint;
+	}
+
+}

--- a/Snake/src/ge/edu/freeuni/sdp/snake/model/LittleMovingBeing.java
+++ b/Snake/src/ge/edu/freeuni/sdp/snake/model/LittleMovingBeing.java
@@ -46,5 +46,11 @@ public abstract class LittleMovingBeing extends MovingBeing{
 	public Point getNeck() {
 		return previousPoint;
 	}
+	
+	@Override
+	public boolean isConnected(Object obj){
+		return getHead().equals(((Being)obj).getHead()) || (getHead().equals(((Being)obj).getNeck()) && 
+				getNeck().equals(((Being)obj).getHead()));
+	}
 
 }

--- a/Snake/src/ge/edu/freeuni/sdp/snake/model/MovingBeing.java
+++ b/Snake/src/ge/edu/freeuni/sdp/snake/model/MovingBeing.java
@@ -20,4 +20,10 @@ public abstract class MovingBeing extends Being {
 	public final void setDirection(Direction direction) {
 		_direction = direction;
 	}
+	
+	@Override
+	public boolean isConnected(Object obj){
+		return getHead().equals(((Being)obj).getHead()) || (getHead().equals(((Being)obj).getNeck()) && 
+				getNeck().equals(((Being)obj).getHead()));
+	}
 }

--- a/Snake/src/ge/edu/freeuni/sdp/snake/model/MovingBeing.java
+++ b/Snake/src/ge/edu/freeuni/sdp/snake/model/MovingBeing.java
@@ -21,9 +21,4 @@ public abstract class MovingBeing extends Being {
 		_direction = direction;
 	}
 	
-	@Override
-	public boolean isConnected(Object obj){
-		return getHead().equals(((Being)obj).getHead()) || (getHead().equals(((Being)obj).getNeck()) && 
-				getNeck().equals(((Being)obj).getHead()));
-	}
 }

--- a/Snake/src/ge/edu/freeuni/sdp/snake/model/MovingMouseBeing.java
+++ b/Snake/src/ge/edu/freeuni/sdp/snake/model/MovingMouseBeing.java
@@ -1,0 +1,20 @@
+package ge.edu.freeuni.sdp.snake.model;
+
+
+public class MovingMouseBeing extends LittleMovingBeing{
+	
+	public MovingMouseBeing(Point point) {
+		super(point);
+	}
+
+	@Override
+	public BeingKind getKind() {
+		return BeingKind.FoodMouse;
+	}
+
+	@Override
+	public void interactWith(Being other) {
+		
+	}
+
+}

--- a/Snake/src/ge/edu/freeuni/sdp/snake/model/MovingMousePopulator.java
+++ b/Snake/src/ge/edu/freeuni/sdp/snake/model/MovingMousePopulator.java
@@ -1,0 +1,15 @@
+package ge.edu.freeuni.sdp.snake.model;
+
+public class MovingMousePopulator extends RandomPositionPopulator{
+	private MovingMouseBeing mouse;
+
+	@Override
+	public void populate(Universe universe) {
+		if (mouse == null || !mouse.isAlive()) {
+			Point point = getRandomUnocupied(universe);
+			mouse = new MovingMouseBeing(point);
+			universe.addBeing(mouse);
+		}
+	}
+
+}

--- a/Snake/src/ge/edu/freeuni/sdp/snake/model/MovingPoisonBeing.java
+++ b/Snake/src/ge/edu/freeuni/sdp/snake/model/MovingPoisonBeing.java
@@ -1,0 +1,20 @@
+package ge.edu.freeuni.sdp.snake.model;
+
+public class MovingPoisonBeing extends LittleMovingBeing{
+	
+
+	public MovingPoisonBeing(Point point) {
+		super(point);
+	}
+
+	@Override
+	public BeingKind getKind() {
+		return BeingKind.FoodPoison;
+	}
+
+	@Override
+	public void interactWith(Being other) {
+		other.kill();
+	}
+
+}

--- a/Snake/src/ge/edu/freeuni/sdp/snake/model/MovingPoisonPopulator.java
+++ b/Snake/src/ge/edu/freeuni/sdp/snake/model/MovingPoisonPopulator.java
@@ -1,0 +1,15 @@
+package ge.edu.freeuni.sdp.snake.model;
+
+public class MovingPoisonPopulator extends RandomPositionPopulator{
+	private MovingPoisonBeing poison;
+	
+	@Override
+	public void populate(Universe universe) {
+		if (poison == null) {
+			Point point = getRandomUnocupied(universe);
+			poison = new MovingPoisonBeing(point);
+			universe.addBeing(poison);
+		}
+	}
+
+}

--- a/Snake/src/ge/edu/freeuni/sdp/snake/model/Snake.java
+++ b/Snake/src/ge/edu/freeuni/sdp/snake/model/Snake.java
@@ -29,7 +29,7 @@ public class Snake extends MovingBeing {
 	};
 
 	@Override
-	public void interactWith(Being other) {
+	public void interactWith(Being other) {	
 		other.kill();
 		grow();
 	};
@@ -48,4 +48,10 @@ public class Snake extends MovingBeing {
 		while (_body.size() > _length)
 			_body.removeLast();
 	}
+	
+	@Override
+	public Point getNeck() {
+		return _body.get(1);
+	}
+	
 }

--- a/Snake/src/ge/edu/freeuni/sdp/snake/model/Snake.java
+++ b/Snake/src/ge/edu/freeuni/sdp/snake/model/Snake.java
@@ -54,4 +54,9 @@ public class Snake extends MovingBeing {
 		return _body.get(1);
 	}
 	
+	@Override
+	public boolean isConnected(Object obj){
+		return (((Being)obj).contains(getHead())|| (getHead().equals(((Being)obj).getNeck()) && 
+				getNeck().equals(((Being)obj).getHead())));
+	}
 }

--- a/Snake/src/ge/edu/freeuni/sdp/snake/model/Universe.java
+++ b/Snake/src/ge/edu/freeuni/sdp/snake/model/Universe.java
@@ -26,17 +26,16 @@ public class Universe {
 	 * is implemented in concrete beings method .interactWith()
 	 */
 	public void interact() {
-
 		for (int i = 0; i < _population.size(); i++) {
 			Being current = _population.get(i);
 			for (int j = 0; j < _population.size(); j++) {
 				Being other = _population.get(j);
-
+				
 				Point head = current.getHead();
 				// Skip if its own head, but don't skip own ass
 				if (current == other && head == other.getHead())
 					continue;
-				if (other.contains(head)) {
+				if (other.isConnected(current)) {
 					other.interactWith(current);
 				}
 			}


### PR DESCRIPTION
Universe კლასის interact() მეთოდი.
if (other.contains(head)) {
    other.interactWith(current);
}
როცა თაგვი და საწამლავი მოძრაობენ, იმის გასარკვევად, შეჭამა თუ არა რომელიმე გველმა, ეს შემოწმება აღარ გამოდგება. წარმოიშვება რამდენიმე ბაგი:
1) როცა თაგვი ან საწამლავი head-ისგან განსხვავებულ ადგილზე გადაკვეთს გველს, გველის contains მეთოდი დააბრუნებს true-ს და ის შეჭამს მის ტანზე გადამვლელ being-ს, არადა , როგორც ვთქვით, ტანთან შეხება არ უნდა ითვლებოდეს.  
2) როცა საწამლავი და გველი პირისპირ დგანან (head-ებს შორის ცარიელი უჯრა არაა) და ერთმანეთისკენ გადადგამენ ნაბიჯს, გველის contains მეთოდი დააბრუნებს true-ს და გველი მოკლავს საწამლავს, მაგრამ საწამლავის contains მეთოდი, რომელიც ამოწმებს გველის head-ს შეიცავს თუ არა, დააბრუნებს false-ს და გველი არ მოკვდება, როცა საწამლავისგან უნდა მომკვდარიყო.
ამ პრობლემების გადასაჭრელად დამჭირდა უკვე შექმნილი კლასების გადაკეთება. კერძოდ Being კლასს დავუმატე ორი მეთოდი: getNeck() - აბრუნებს წინა head-ს, isConnected(Object obj)
- გვეუბნება უნდა გამოვიძახოთ თუ არა interactWith. ამ ახალ მეთოდს ვიყენებ ახლა შესამოწმებლად. შვილობილ კლასებში ის შესაბამისად გადავტვირთე. ამ შემოწმების დასაწერად მოძრავ Being-ებში საჭირო გახდა წინა head-ის მნიშვნელობა და სწორედ ამიტომ დავამატე getNeck() მეთოდი. ეს საჭირო იყო 2) ბაგის გასასწორებლად.
